### PR TITLE
Add support for GUI binding that does not require synchronization (i.e. Intraweb components).

### DIFF
--- a/FidoGui.md
+++ b/FidoGui.md
@@ -12,7 +12,7 @@ The `MVVMExample` project shows how binding can be achieved, the main points are
 
 - Make use of  the `TDelegateObservable` as base for the view model that will consume the Entity.
 
-- Decorate the forms components that need binding with the `UnidirectionalToGuiBinding`, `UnidirectionalToObservableBinding` or `BidirectionalToObservableBinding` attributes you can find in `Fido.Gui.Binding.Attributes`.
+- Decorate the forms components that need binding with the `UnidirectionalToSyncGuiBinding` (when the component needs synchronization), `UnidirectionalToNoSyncGuiBinding` (when the component doesn't need synchronization), `UnidirectionalToObservableBinding` or `BidirectionalToObservableBinding` attributes you can find in `Fido.Gui.Binding.Attributes`.
 
 - Decorate the forms actions that need binding with the `MethodToActionBinding` attribute you can find in `Fido.Gui.Binding.Attributes`.
 

--- a/examples/MVVMExample/Views/Main.View.pas
+++ b/examples/MVVMExample/Views/Main.View.pas
@@ -31,7 +31,7 @@ type
     [MethodToActionBinding('ShowSong', oeetBefore)]
     // The View observes the ViewModel and sets the Button.Enabled to ViewModel.IsModelNotEmpty
     // everytime there is a notification.
-    [UnidirectionalToGuiBinding('IsModelNotEmpty',  'Enabled')]
+    [UnidirectionalToSyncGuiBinding('IsModelNotEmpty',  'Enabled')]
     ShowButton: TButton;
     SongsDataSource: TDataSource;
     // The SongsGrid.OnTitleClick is bound to the ViewModel.SongsGridTitleClick method that returns the exact
@@ -49,7 +49,7 @@ type
     [MethodToActionBinding('DeleteSong', oeetBefore)]
     // The View observes the ViewModel and sets the Button.Enabled to ViewModel.IsModelNotEmpty
     // everytime there is a notification.
-    [UnidirectionalToGuiBinding('IsModelNotEmpty',  'Enabled')]
+    [UnidirectionalToSyncGuiBinding('IsModelNotEmpty',  'Enabled')]
     DeleteButton: TButton;
     actDeleteSong: TAction;
     procedure SongsGridDblClick(Sender: TObject);

--- a/source/Binding/Fido.Gui.Binding.Attributes.pas
+++ b/source/Binding/Fido.Gui.Binding.Attributes.pas
@@ -35,8 +35,20 @@ type
 
 
 
-  // Unidirectional binding from Observable to Gui component
-  UnidirectionalToGuiBindingAttribute = class(GuiBindingAttribute)
+  // Unidirectional binding from Observable to Gui component that requires Synchronization
+  UnidirectionalToSyncGUIBindingAttribute = class(GuiBindingAttribute)
+  private
+    FSourceAttributeName: string;
+    FDestinationAttributeName: string;
+  public
+    constructor Create(const SourceAttributeName: string; const DestinationAttributeName: string);
+
+    property SourceAttributeName: string read FSourceAttributeName;
+    property DestinationAttributeName: string read FDestinationAttributeName;
+  end;
+
+  // Unidirectional binding from Observable to Gui component that does not require Synchronization
+  UnidirectionalToNoSyncGUIBindingAttribute = class(GuiBindingAttribute)
   private
     FSourceAttributeName: string;
     FDestinationAttributeName: string;
@@ -102,9 +114,9 @@ implementation
 { BidirectionalToObservableBindingAttribute }
 
 constructor BidirectionalToObservableBindingAttribute.Create(
-  const SourceAttributeName,
-        DestinationAttributeName,
-        DestinationEventName: string);
+  const SourceAttributeName: string;
+  const DestinationAttributeName: string;
+  const DestinationEventName: string);
 begin
   inherited Create;
   FSourceAttributeName := SourceAttributeName;
@@ -112,11 +124,11 @@ begin
   FDestinationEventName := DestinationEventName;
 end;
 
-{ UnidirectionalToVclBindingAttribute }
+{ UnidirectionalToSyncGUIBindingAttribute }
 
-constructor UnidirectionalToGuiBindingAttribute.Create(
-  const SourceAttributeName,
-        DestinationAttributeName: string);
+constructor UnidirectionalToSyncGUIBindingAttribute.Create(
+  const SourceAttributeName: string;
+  const DestinationAttributeName: string);
 begin
   inherited Create;
   FSourceAttributeName := SourceAttributeName;
@@ -126,9 +138,9 @@ end;
 { UnidirectionalToObservableBindingAttribute }
 
 constructor UnidirectionalToObservableBindingAttribute.Create(
-  const SourceAttributeName,
-        SourceEventName,
-        DestinationAttributeName: string);
+  const SourceAttributeName: string;
+  const SourceEventName: string;
+  const DestinationAttributeName: string);
 begin
   inherited Create;
   FSourceAttributeName := SourceAttributeName;
@@ -155,6 +167,17 @@ constructor BindEventAttribute.Create(
 begin
   FObservableEventFunc := ObservableEventFunc;
   FComponentEvent := ComponentEvent;
+end;
+
+{ UnidirectionalToNoSyncGUIBindingAttribute }
+
+constructor UnidirectionalToNoSyncGUIBindingAttribute.Create(
+  const SourceAttributeName: string;
+  const DestinationAttributeName: string);
+begin
+  inherited Create;
+  FSourceAttributeName := SourceAttributeName;
+  FDestinationAttributeName := DestinationAttributeName;
 end;
 
 end.

--- a/source/Binding/Fido.Gui.Fmx.Binding.pas
+++ b/source/Binding/Fido.Gui.Fmx.Binding.pas
@@ -48,7 +48,10 @@ type
 
   GuiBinding = class
   private
-    class procedure SetupObservableToComponent<DomainObject: IObservable; Component: TComponent>(const Source: DomainObject; const SourceAttributeName: string; const Destination: Component;
+    class procedure SetupObservableToSyncGUIComponent<DomainObject: IObservable; Component: TComponent>(const Source: DomainObject; const SourceAttributeName: string; const Destination: Component;
+      const DestinationAttributeName: string); overload; static;
+
+    class procedure SetupObservableToNoSyncGUIComponent<DomainObject: IObservable; Component: TComponent>(const Source: DomainObject; const SourceAttributeName: string; const Destination: Component;
       const DestinationAttributeName: string); overload; static;
 
     class procedure SetupComponentToObservable<Component: TComponent; DomainObject: IObservable>(const Source: Component; const SourceAttributeName: string; const SourceEventName: string;
@@ -125,7 +128,7 @@ begin
     oeetAfter);
 end;
 
-class procedure GuiBinding.SetupObservableToComponent<DomainObject, Component>(
+class procedure GuiBinding.SetupObservableToNoSyncGUIComponent<DomainObject, Component>(
   const Source: DomainObject;
   const SourceAttributeName: string;
   const Destination: Component;
@@ -166,7 +169,65 @@ begin
   end;
 
   Source.RegisterObserver(
-    TAnonGUIObserver<Component>.Create(
+    TAnonObserver<Component>.Create(
+      Destination,
+      procedure(Dest: Component; Notification: INotification)
+      var
+        Value: TValue;
+      begin
+        if Assigned(SourceProperty) then
+          Value := SourceProperty.GetValue(TValue.From(Source).AsType<IObserver>)
+        else if Assigned(SourceMethod) then
+          Value := SourceMethod.Invoke(TValue.From(Source), []);
+
+        if Assigned(DestinationProperty) then
+          DestinationProperty.SetValue(Dest as TComponent, Value);
+
+      end));
+end;
+
+class procedure GuiBinding.SetupObservableToSyncGUIComponent<DomainObject, Component>(
+  const Source: DomainObject;
+  const SourceAttributeName: string;
+  const Destination: Component;
+  const DestinationAttributeName: string);
+var
+  RttiContext: TRttiContext;
+  DestinationProperty: TRttiProperty;
+  SourceProperty: TRttiProperty;
+  SourceMethod: TRttiMethod;
+begin
+  DestinationProperty := nil;
+  DestinationProperty := RttiContext.GetType(Destination.ClassType).GetProperty(DestinationAttributeName);
+  if Assigned(DestinationProperty) and not DestinationProperty.IsWritable then
+    DestinationProperty := nil;
+
+  if not Assigned(DestinationProperty) then
+    raise EFidoGuiBindingException.CreateFmt('Binding error. Property "%s.%s" does not exist.', [Destination.Name, DestinationAttributeName]);
+
+  SourceMethod := nil;
+  SourceProperty := nil;
+  SourceProperty := RttiContext.GetType(TypeInfo(DomainObject)).GetProperty(SourceAttributeName);
+  if Assigned(SourceProperty) and not SourceProperty.IsReadable then
+    SourceProperty := nil;
+  if not Assigned(SourceProperty) then
+  begin
+    if SourceAttributeName.StartsWith('Get') then
+      SourceMethod := RttiContext.GetType(TypeInfo(DomainObject)).GetMethod(SourceAttributeName)
+    else
+    begin
+      SourceMethod := RttiContext.GetType(TypeInfo(DomainObject)).GetMethod(SourceAttributeName);
+      if not Assigned(SourceMethod) then
+        SourceMethod := RttiContext.GetType(TypeInfo(DomainObject)).GetMethod('Get' +SourceAttributeName);
+    end;
+    if Assigned(SourceMethod) and not ((SourceMethod.MethodKind = mkFunction) and (Length(SourceMethod.GetParameters) = 0)) then
+      SourceMethod := nil;
+    if not Assigned(SourceMethod) then
+      raise EFidoGuiBindingException.CreateFmt('Binding error. Attribute "%s" does not exist for source.', [SourceAttributeName]);
+  end;
+
+  Source.RegisterObserver(
+    TAnonSyncObserver<Component>.Create(
       Destination,
       procedure(Dest: Component; Notification: INotification)
       var
@@ -201,12 +262,18 @@ begin
       TCollections.CreateList<TCustomAttribute>(Field.GetAttributes).ForEach(
         procedure(const Attribute: TCustomAttribute)
         begin
-          if Attribute is UnidirectionalToGuiBindingAttribute then
-            GuiBinding.SetupObservableToComponent(
+          if Attribute is UnidirectionalToSyncGUIBindingAttribute then
+            GuiBinding.SetupObservableToSyncGUIComponent(
               Observable,
-              (Attribute as UnidirectionalToGuiBindingAttribute).SourceAttributeName,
+              (Attribute as UnidirectionalToSyncGUIBindingAttribute).SourceAttributeName,
               GuiComponent.FindComponent(Field.Name),
-              (Attribute as UnidirectionalToGuiBindingAttribute).DestinationAttributeName);
+              (Attribute as UnidirectionalToSyncGUIBindingAttribute).DestinationAttributeName);
+          if Attribute is UnidirectionalToNoSyncGUIBindingAttribute then
+            GuiBinding.SetupObservableToNoSyncGUIComponent(
+              Observable,
+              (Attribute as UnidirectionalToNoSyncGUIBindingAttribute).SourceAttributeName,
+              GuiComponent.FindComponent(Field.Name),
+              (Attribute as UnidirectionalToNoSyncGUIBindingAttribute).DestinationAttributeName);
           if Attribute is UnidirectionalToObservableBindingAttribute then
             GuiBinding.SetupComponentToObservable<Component, DomainObject>(
               GuiComponent.FindComponent(Field.Name),
@@ -340,7 +407,7 @@ class procedure GuiBinding.SetupBidirectional<DomainObject, Component>(
   const DestinationAttributeName: string;
   const DestinationEventName: string);
 begin
-  Guibinding.SetupObservableToComponent<DomainObject, Component>(Source, SourceAttributeName, Destination, DestinationAttributeName);
+  Guibinding.SetupObservableToSyncGUIComponent<DomainObject, Component>(Source, SourceAttributeName, Destination, DestinationAttributeName);
   Guibinding.SetupComponentToObservable<Component, DomainObject>(Destination, DestinationAttributeName, DestinationEventName, Source, SourceAttributeName);
 end;
 

--- a/source/DesignPatterns/Fido.DesignPatterns.Observable.Delegated.pas
+++ b/source/DesignPatterns/Fido.DesignPatterns.Observable.Delegated.pas
@@ -222,7 +222,7 @@ begin
       Exit;
 
     FObservers.Add(Observer);
-    FNeedsSync := FNeedsSync or Supports(Observer, IGUIObserver);
+    FNeedsSync := FNeedsSync or Supports(Observer, ISyncObserver);
   finally
     FLock.EndWrite;
   end;
@@ -300,7 +300,7 @@ begin
         if not IsAlive or (Target = Observer) then
           FObservers.Delete(I)
         else
-          FNeedsSync := FNeedsSync or Supports(Target, IGUIObserver);
+          FNeedsSync := FNeedsSync or Supports(Target, ISyncObserver);
   finally
     FLock.EndWrite;
   end;

--- a/source/DesignPatterns/Fido.DesignPatterns.Observer.Intf.pas
+++ b/source/DesignPatterns/Fido.DesignPatterns.Observer.Intf.pas
@@ -35,7 +35,7 @@ type
   end;
 
   // observer that needs GUI synchronisation when being notified
-  IGUIObserver = interface(IObserver)
+  ISyncObserver = interface(IObserver)
     ['{FA835B4A-8D02-4DA6-8A3D-69676A5EFE2E}']
   end;
 

--- a/source/DesignPatterns/Fido.Gui.Fmx.DesignPatterns.Observer.Anon.pas
+++ b/source/DesignPatterns/Fido.Gui.Fmx.DesignPatterns.Observer.Anon.pas
@@ -55,7 +55,7 @@ type
     procedure Notify(const Sender: IInterface; const Notification: INotification);
   end;
 
-  TAnonGUIObserver<T: class> = class(TAnonObserver<T>, IGUIObserver);
+  TAnonSyncObserver<T: class> = class(TAnonObserver<T>, ISyncObserver);
 
 implementation
 

--- a/source/DesignPatterns/Fido.Gui.Vcl.DesignPatterns.Observer.Anon.pas
+++ b/source/DesignPatterns/Fido.Gui.Vcl.DesignPatterns.Observer.Anon.pas
@@ -55,7 +55,7 @@ type
     procedure Notify(const Sender: IInterface; const Notification: INotification);
   end;
 
-  TAnonGUIObserver<T: class> = class(TAnonObserver<T>, IGUIObserver);
+  TAnonSyncObserver<T: class> = class(TAnonObserver<T>, ISyncObserver);
 
 implementation
 


### PR DESCRIPTION
WARNING: UnidirectionalToGUIBindingAttribute must be replaced with UnidirectionalToSyncGUIBindingAttribute in existing code.
