### PR TITLE
Fixes 20240226

### DIFF
--- a/source/Api/Client/VirtualApi/Fido.Api.Client.VirtualApi.json.pas
+++ b/source/Api/Client/VirtualApi/Fido.Api.Client.VirtualApi.json.pas
@@ -167,8 +167,11 @@ begin
     on E: Exception do
     begin
       Headers := Shared.Make(TStringList.Create);
-      for var Pair in Response.Headers do
-        Headers.AddPair(Pair.Name, Pair.Value);
+      if Assigned(Response) then
+      begin
+        for var Pair in Response.Headers do
+          Headers.AddPair(Pair.Name, Pair.Value);
+      end;
       Call.Finish(-1, E.Message, Headers);
     end;
   end;

--- a/source/Db/Fido.Db.Connections.FireDac.pas
+++ b/source/Db/Fido.Db.Connections.FireDac.pas
@@ -50,7 +50,7 @@ type
     constructor Create(const Parameters: TStrings; const PerXDictionaryFactoryFunc: Func<TDictionaryOwnerships, Func<TFDConnection>, IPerXDictionary<TFDConnection>>);
     destructor Destroy; override;
 
-    function GetCurrent: TFDConnection;
+    function GetCurrent: TFDConnection; virtual;
   end;
 
 implementation

--- a/source/Db/Fido.Db.ListDataset.pas
+++ b/source/Db/Fido.Db.ListDataset.pas
@@ -355,6 +355,8 @@ begin
         end
         // else try standard, supported types
         else if DataTypeConverter.GotDescriptor(LMethodInfo.VariableTypeName, DataTypeDescriptor) then
+          AddFieldDef(Prefix + LMethodInfo.FieldName, DataTypeDescriptor.FieldType)
+        else if DataTypeConverter.GotDescriptor(LRttiMeth.ReturnType, DataTypeDescriptor) then
           AddFieldDef(Prefix + LMethodInfo.FieldName, DataTypeDescriptor.FieldType);
       end);
 end;

--- a/source/Db/Fido.Db.ListDataset.pas
+++ b/source/Db/Fido.Db.ListDataset.pas
@@ -317,7 +317,9 @@ begin
             FTraversedTypeInfoMap[LRttiProp.PropertyType.AsInstance.Handle] := LTraverseCount + 1;
             InternalInitFieldDefsObjectClass(LRttiProp.PropertyType.AsInstance.Handle,
                                              Prefix + LRttiProp.Name + '.');
-          end;
+          end
+          else
+            FTraversedTypeInfoMap[LRttiProp.PropertyType.AsInstance.Handle] := LTraverseCount - 1;
         end
         // 2. try framework-approved basic datatypes handled by DataTypeConverter
         else if DataTypeConverter.GotDescriptor(LRttiProp.PropertyType, DataTypeDescriptor) then
@@ -347,7 +349,9 @@ begin
           begin
             FTraversedTypeInfoMap[LMethodInfo.Handle] := LTraverseCount + 1;
             InternalInitFieldDefsObjectClass(LMethodInfo.Handle, Prefix + LMethodInfo.FieldName + '.');
-          end;
+          end
+          else
+            FTraversedTypeInfoMap[LMethodInfo.Handle] := LTraverseCount - 1;
         end
         // else try standard, supported types
         else if DataTypeConverter.GotDescriptor(LMethodInfo.VariableTypeName, DataTypeDescriptor) then

--- a/source/Db/Fido.Db.TypeConverter.pas
+++ b/source/Db/Fido.Db.TypeConverter.pas
@@ -38,7 +38,8 @@ uses
   Fido.Types.TGuid.Variant;
 
 type
-  TBaseType = (btVariant, btInteger, btString, btDouble, btDate, btDateTime, btInt64, btBoolean, btCurrency, btExtended, btGuid, btSmallint);
+  TBaseType = (btVariant, btInteger, btString, btDouble, btDate, btDateTime, btInt64, btBoolean, btCurrency, btExtended, btGuid, btSmallint,
+    btEnum);
 
   EFidoUnsupportedTypeError = class (EFidoException);
 
@@ -62,7 +63,8 @@ type
     BaseTypeNames : array[TBaseType] of string = (
       'SYSTEM.VARIANT', 'SYSTEM.INTEGER', 'SYSTEM.STRING', 'SYSTEM.DOUBLE',
       'SYSTEM.TDATE', 'SYSTEM.TDATETIME', 'SYSTEM.INT64', 'SYSTEM.BOOLEAN',
-      'SYSTEM.CURRENCY', 'SYSTEM.EXTENDED', 'SYSTEM.TGUID', 'SYSTEM.SMALLINT');
+      'SYSTEM.CURRENCY', 'SYSTEM.EXTENDED', 'SYSTEM.TGUID', 'SYSTEM.SMALLINT',
+      'SYSTEM.ENUM');
   strict private class var
       FTypeCache: IDictionary<string, TDataTypeDescriptor>;
   strict private
@@ -154,6 +156,9 @@ begin
   AddTypeDescriptor(btBoolean, true, tkRecord, ftBoolean);
   AddTypeDescriptor(btGuid, true, tkRecord, ftGuid);
   AddTypeDescriptor(btSmallint, true, tkRecord, ftSmallint);
+
+
+  AddTypeDescriptor(btEnum, false, tkEnumeration, ftInteger);
 end;
 
 class function DataTypeConverter.GetDescriptor(const RttiType: TRttiType): TDataTypeDescriptor;
@@ -172,8 +177,14 @@ end;
 class function DataTypeConverter.GotDescriptor(
   const RttiType: TRttiType;
   out Descriptor: TDataTypeDescriptor): boolean;
+var
+  _RttiTypeQualifiedName: string;
 begin
-  Result := GotDescriptor(RttiType.QualifiedName, Descriptor);
+  _RttiTypeQualifiedName := RttiType.QualifiedName;
+  if (RttiType.TypeKind = tkEnumeration) and (not RttiType.QualifiedName.ToUpper.Equals('SYSTEM.BOOLEAN')) then
+     _RttiTypeQualifiedName := 'SYSTEM.ENUM';
+
+  Result := GotDescriptor(_RttiTypeQualifiedName, Descriptor);
 end;
 
 { TDataTypeDescriptor }

--- a/source/Db/Fido.Db.VirtualDataset.pas
+++ b/source/Db/Fido.Db.VirtualDataset.pas
@@ -244,13 +244,13 @@ procedure VirtualDatasetErrorFmt(const Message: string; const Args: array of con
 
 implementation
 
-function FieldListCheckSum(Dataset: TDataSet): Integer;
+function FieldListCheckSum(Dataset: TDataSet): NativeInt;
 var
-  I: Integer;
+  I: NativeInt;
 begin
   Result := 0;
   for I := 0 to Dataset.Fields.Count - 1 do
-    Result := Result + (Integer(Dataset.Fields[I]) shr (I mod 16));
+    Result := Result + (NativeInt(Dataset.Fields[I]) shr (I mod 16));
 end;
 
 procedure VirtualDatasetError(
@@ -1119,7 +1119,7 @@ begin
   FInternalOpen := True;
   FCurrent := -1;
 
-  BookmarkSize := sizeof(Integer);
+  BookmarkSize := sizeof(NativeInt);
 
   FieldDefs.Updated := False;
   FieldDefs.Update;

--- a/source/Json/Fido.JSON.Marshalling.pas
+++ b/source/Json/Fido.JSON.Marshalling.pas
@@ -1223,6 +1223,7 @@ var
   Mapping: MappingsUtilities.TJSONMarshallingMapping;
   MarshalledValue: Nullable<string>;
   FloatValue: Extended;
+  FormatSettings: TFormatSettings;
 begin
   Result := nil;
 
@@ -1271,9 +1272,12 @@ begin
     tkFloat,
     tkInteger,
     tkInt64: begin
+      FormatSettings := TFormatSettings.Create;
+      FormatSettings.ThousandSeparator := ',';
+      FormatSettings.DecimalSeparator := '.';
       MarshalledValue := JSONMarshaller.FromPrimitive(Value, RttiType.Handle, ConfigurationName);
       if MarshalledValue.HasValue then
-        if not TryStrToFloat(MarshalledValue.Value, FloatValue) then
+        if not TryStrToFloat(MarshalledValue.Value, FloatValue, FormatSettings) then
           Result := TJSONString.Create(MarshalledValue)
         else
           Result := TJSONUnQuotedString.Create(MarshalledValue);

--- a/source/Json/Fido.JSON.Marshalling.pas
+++ b/source/Json/Fido.JSON.Marshalling.pas
@@ -1222,8 +1222,6 @@ var
   RttiType: TRttiType;
   Mapping: MappingsUtilities.TJSONMarshallingMapping;
   MarshalledValue: Nullable<string>;
-  FloatValue: Extended;
-  FormatSettings: TFormatSettings;
 begin
   Result := nil;
 
@@ -1272,15 +1270,9 @@ begin
     tkFloat,
     tkInteger,
     tkInt64: begin
-      FormatSettings := TFormatSettings.Create;
-      FormatSettings.ThousandSeparator := ',';
-      FormatSettings.DecimalSeparator := '.';
       MarshalledValue := JSONMarshaller.FromPrimitive(Value, RttiType.Handle, ConfigurationName);
       if MarshalledValue.HasValue then
-        if not TryStrToFloat(MarshalledValue.Value, FloatValue, FormatSettings) then
-          Result := TJSONString.Create(MarshalledValue)
-        else
-          Result := TJSONUnQuotedString.Create(MarshalledValue);
+        Result := TJSONUnQuotedString.Create(MarshalledValue);
     end;
     tkRecord,
     tkMRecord: begin

--- a/source/Redis/Fido.Redis.KVStore.pas
+++ b/source/Redis/Fido.Redis.KVStore.pas
@@ -48,7 +48,7 @@ type
 
     function Is1(const Value: Integer): Boolean;
     function DoDelete(const Timeout: Cardinal): Context<string>.MonadFunc<Integer>;
-    function DoGet(const Timeout: Integer): Context<string>.FunctorFunc<string>;
+    function DoGet(const Timeout: Cardinal): Context<string>.FunctorFunc<string>;
     function GetValueOrDefault(const Value: Nullable<string>): string;
     function DoPut(const Timeout: Cardinal): Context<TArray<string>>.MonadFunc<Boolean>;
   public
@@ -101,7 +101,8 @@ begin
   Result := Format('%s%s', [FKeyPrefix, Key]);
 end;
 
-function TRedisKVStore.DoGet(const Timeout: Integer): Context<string>.FunctorFunc<string>;
+function TRedisKVStore.DoGet(const Timeout: Cardinal):
+    Context<string>.FunctorFunc<string>;
 var
   Client: IFidoRedisClient;
 begin
@@ -125,7 +126,7 @@ begin
     New(Context<string>.
       New(Key).
       Map<string>(FormatKey)).
-    Map<string>(DoGet(Timeout), Retries.GetRetriesOnExceptionFunc());
+  Map<string>(DoGet(Timeout), Retries.GetRetriesOnExceptionFunc());
 end;
 
 function TRedisKVStore.Is1(const Value: Integer): Boolean;

--- a/tests/Json/Tests.JSON.Marshalling.pas
+++ b/tests/Json/Tests.JSON.Marshalling.pas
@@ -117,6 +117,9 @@ type
     procedure JSONMarshallingFromInteger;
 
     [Test]
+    procedure JSONMarshallingFromFloatingPointValues;
+
+    [Test]
     procedure JSONUnmarshallingToNullableInteger;
 
     [Test]
@@ -273,6 +276,13 @@ begin
   List := TCollections.CreateList<TTestEnum>([Enum1, Enum2]);
 
   Assert.AreEqual('[0,1]', JSONMarshaller.From<IReadOnlyList<TTestEnum>>(List.AsReadOnly));
+end;
+
+procedure TJSONMarshallingTests.JSONMarshallingFromFloatingPointValues;
+begin
+  Assert.AreEqual('5.56', JSONMarshaller.From<Extended>(5.56));
+  Assert.AreEqual('5.56', JSONMarshaller.From<Double>(5.56));
+  Assert.AreEqual('5.56', JSONMarshaller.From<Currency>(5.56));
 end;
 
 procedure TJSONMarshallingTests.JSONMarshallingFromInt64;


### PR DESCRIPTION
+ Avoid an AV in virtual json api when response is nil
+ 64bit compliance in virtualataset
+ GetCurrent set virtual for "mockability" in in FireDAC connections
+ Fixed definition of objects field in dataset (The recursion stopped when the first object type. The second correctly was not included, but the following where not included, too)
+ Fixed conversion of floating values in json marshalling
+ Fixed a type definition in Redis KVStore 